### PR TITLE
Change metric order in CVSS3 toString method

### DIFF
--- a/ae-cvss-calculator/__tests__/ApplyPartsIfMetricTest.ts
+++ b/ae-cvss-calculator/__tests__/ApplyPartsIfMetricTest.ts
@@ -58,7 +58,7 @@ describe('CvssVectorTest', () => {
     it('applyPartsIfMetricV31Test', () => {
         assertPartsLowerHigherApplied(
             "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:N/RL:O/MAC:H", "CVSS:3.1/AV:N/MAV:P/AC:H/MAC:H/E:U/RL:W/CR:M",
-            "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:N/I:L/A:N/E:U/RL:O/MAV:P/MAC:H/CR:M",
+            "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:N/I:L/A:N/E:U/RL:O/CR:M/MAV:P/MAC:H",
             "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:N/RL:W/MAC:H");
         {
             const i = "CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H/E:H/RL:U/RC:C";
@@ -77,8 +77,8 @@ describe('CvssVectorTest', () => {
         assertPartsLowerHigherApplied(
             "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "CVSS:3.1/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:N/MI:N/MA:N/CR:H/IR:M/AR:L",
             // CR:H is not applied, since medium is the center where ND is equals
-            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MAV:P/MAC:H/MPR:H/MUI:R/MC:N/MI:N/MA:N/IR:M/AR:L",
-            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MS:C/CR:H");
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/IR:M/AR:L/MAV:P/MAC:H/MPR:H/MUI:R/MC:N/MI:N/MA:N",
+            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/CR:H/MS:C");
         // temporal lowest set values
         assertPartsLowerHigherApplied(
             "CVSS:3.1/E:U/RL:O/RC:U", "CVSS:3.1/E:X/RL:X/RC:X",
@@ -128,7 +128,7 @@ describe('CvssVectorTest', () => {
     it('applyPartsIfMetricV30Test', () => {
         assertPartsLowerHigherApplied(
             "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:N/RL:O/MAC:H", "CVSS:3.0/AV:N/MAV:P/AC:H/MAC:H/E:U/RL:W/CR:M",
-            "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:C/C:N/I:L/A:N/E:U/RL:O/MAV:P/MAC:H/CR:M",
+            "CVSS:3.0/AV:N/AC:H/PR:L/UI:N/S:C/C:N/I:L/A:N/E:U/RL:O/CR:M/MAV:P/MAC:H",
             "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:N/RL:W/MAC:H");
         {
             const i = "CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:C/C:H/I:H/A:H/E:H/RL:U/RC:C";
@@ -147,8 +147,8 @@ describe('CvssVectorTest', () => {
         assertPartsLowerHigherApplied(
             "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "CVSS:3.0/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:N/MI:N/MA:N/CR:H/IR:M/AR:L",
             // CR:H is not applied, since medium is the center where ND is equals
-            "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MAV:P/MAC:H/MPR:H/MUI:R/MC:N/MI:N/MA:N/IR:M/AR:L",
-            "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/MS:C/CR:H");
+            "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/IR:M/AR:L/MAV:P/MAC:H/MPR:H/MUI:R/MC:N/MI:N/MA:N",
+            "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/CR:H/MS:C");
         // temporal lowest set values
         assertPartsLowerHigherApplied(
             "CVSS:3.0/E:U/RL:O/RC:U", "CVSS:3.0/E:X/RL:X/RC:X",

--- a/ae-cvss-calculator/__tests__/Cvss3P0Test.ts
+++ b/ae-cvss-calculator/__tests__/Cvss3P0Test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Cvss3P0} from "../src";
+import { Cvss3P0 } from "../src";
 
 import fs from "fs";
 
@@ -85,5 +85,11 @@ describe('Cvss3P0', () => {
         expect(makeNanFromUndefined(result.environmental)).toEqual(NaN);
         expect(makeNanFromUndefined(result.modifiedImpact)).toEqual(NaN);
         expect(makeNanFromUndefined(result.overall)).toEqual(0.0);
+    });
+
+    it('should serialize the metrics in the correct order', () => {
+        // see https://github.com/org-metaeffekt/metaeffekt-core/pull/290
+        const cvss = new Cvss3P0("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/MAV:A/MAC:H/MS:C/MC:N/MI:L/MA:N/CR:H");
+        expect(cvss.toString(true)).toEqual("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/CR:H/IR:X/AR:X/MAV:A/MAC:H/MPR:X/MUI:X/MS:C/MC:N/MI:L/MA:N");
     });
 });

--- a/ae-cvss-calculator/__tests__/Cvss3P1Test.ts
+++ b/ae-cvss-calculator/__tests__/Cvss3P1Test.ts
@@ -94,4 +94,10 @@ describe('Cvss3P1', () => {
         expect(makeNanFromUndefined(result.modifiedImpact)).toEqual(NaN);
         expect(makeNanFromUndefined(result.overall)).toEqual(7.8);
     });
+
+    it('should serialize the metrics in the correct order', () => {
+        // see https://github.com/org-metaeffekt/metaeffekt-core/pull/290
+        const cvss = new Cvss3P1("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/MAV:A/MAC:H/MS:C/MC:N/MI:L/MA:N/CR:H");
+        expect(cvss.toString(true)).toEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:W/RC:R/CR:H/IR:X/AR:X/MAV:A/MAC:H/MPR:X/MUI:X/MS:C/MC:N/MI:L/MA:N");
+    });
 });

--- a/ae-cvss-calculator/__tests__/Cvss4P0Test.ts
+++ b/ae-cvss-calculator/__tests__/Cvss4P0Test.ts
@@ -93,7 +93,8 @@ describe('Cvss4P0', () => {
         const cvss = new Cvss4P0("CVSS:4.0/AV:P/AC:H/AT:P/PR:L/UI:P/VC:L/VI:L/VA:L/SC:H/SI:L/SA:L/S:P/R:I/U:Red/MAT:P/MPR:N/MUI:P/MVC:N/MVI:L/MVA:L/MSC:L/MSI:L/MSA:S/IR:M/AR:H/E:U");
         const scores = cvss.calculateScores();
         expect(scores.overall).toEqual(1.0);
-        expect(scores.base).toEqual(2.1);
+        expect(scores.base).toEqual(1.0);
+        expect(scores.baseMetricsOnly).toEqual(2.1);
         expect(scores.environmental).toEqual(4.6);
         expect(scores.threat).toEqual(0.3);
     });

--- a/ae-cvss-calculator/src/cvss3p0/Cvss3P0Components.ts
+++ b/ae-cvss-calculator/src/cvss3p0/Cvss3P0Components.ts
@@ -985,7 +985,7 @@ export class Cvss3P0Components {
     };
 
     public static readonly ENVIRONMENTAL_CATEGORY_VALUES: VectorComponent<VectorComponentValue>[] = [
-        this.MAV, this.MAC, this.MPR, this.MUI, this.MS, this.MC, this.MI, this.MA, this.CR, this.IR, this.AR
+        this.CR, this.IR, this.AR, this.MAV, this.MAC, this.MPR, this.MUI, this.MS, this.MC, this.MI, this.MA
     ];
 
     static readonly REGISTERED_COMPONENTS = new Map<ComponentCategory, VectorComponent<VectorComponentValue>[]>();

--- a/ae-cvss-calculator/src/cvss3p1/Cvss3P1Components.ts
+++ b/ae-cvss-calculator/src/cvss3p1/Cvss3P1Components.ts
@@ -985,7 +985,7 @@ export class Cvss3P1Components {
     };
 
     public static readonly ENVIRONMENTAL_CATEGORY_VALUES: VectorComponent<VectorComponentValue>[] = [
-        this.MAV, this.MAC, this.MPR, this.MUI, this.MS, this.MC, this.MI, this.MA, this.CR, this.IR, this.AR
+        this.CR, this.IR, this.AR, this.MAV, this.MAC, this.MPR, this.MUI, this.MS, this.MC, this.MI, this.MA
     ];
 
     static readonly REGISTERED_COMPONENTS = new Map<ComponentCategory, VectorComponent<VectorComponentValue>[]>();


### PR DESCRIPTION
See https://github.com/org-metaeffekt/metaeffekt-core/pull/290 for more details.

Adjusted the Cvss3 toString methods to use the metric order as provided in the specification.