### PR TITLE
AE-2020: Change comparison logic for CVSS base/modified metrics

### DIFF
--- a/ae-cvss-calculator/__tests__/ApplyPartsIfMetricTest.ts
+++ b/ae-cvss-calculator/__tests__/ApplyPartsIfMetricTest.ts
@@ -249,6 +249,17 @@ describe('CvssVectorTest', () => {
         );
     });
 
+    it('applyPartsBaseVsModifiedTest', () => {
+        assertPartsLowerHigherApplied("CVSS:4.0/AV:N/MAV:L", "MAV:A",
+            "CVSS:4.0/AV:N/MAV:L",
+            "CVSS:4.0/AV:N/MAV:A"
+        );
+        assertPartsLowerHigherApplied("CVSS:4.0/AV:N", "MAV:A",
+            "CVSS:4.0/AV:N/MAV:A",
+            "CVSS:4.0/AV:N"
+        );
+    });
+
     function assertPartsLowerHigherApplied(originalVector: string, applyMetrics: string, expectedLower: string, expectedHigher: string) {
         const lower = fromVector(originalVector);
         if (lower === null) throw new Error("failed to parse lower vector: " + originalVector);

--- a/ae-cvss-calculator/src/CvssVectorUtilities.ts
+++ b/ae-cvss-calculator/src/CvssVectorUtilities.ts
@@ -131,15 +131,12 @@ function findOldNewSeverityOrder(
     newAttribute: VectorComponentValue | null,
     isNewAttributeModified: boolean
 ): { oldSeverity: number; newSeverity: number } {
-    const isModifiedAttributeSet = modifiedAttribute?.name === 'NOT_DEFINED' || modifiedAttribute?.name === 'NULL';
-    const oldAttribute = isModifiedAttributeSet && isNewAttributeModified ? modifiedAttribute : unmodifiedAttribute;
+    // compare either the modified or the unmodified attribute with the new attribute
+    const isModifiedAttributeSet = modifiedAttribute != null && modifiedAttribute.name !== 'NOT_DEFINED' && modifiedAttribute.name !== 'NULL' && modifiedAttribute.shortName !== 'X';
 
-    /*const order = {
-        oldSeverity: determineAttributeSeverityOrder(self, oldAttribute),
-        newSeverity: determineAttributeSeverityOrder(self, newAttribute)
-    };
-    console.log(" ", order, oldAttribute?.shortName, newAttribute?.shortName)
-    return order;*/
+    // if applying a new modified attribute, evaluate against the existing modified attribute (if set) or fallback to base.
+    // if applying a new base attribute, evaluate only against the existing base attribute.
+    const oldAttribute = isNewAttributeModified && isModifiedAttributeSet ? modifiedAttribute : unmodifiedAttribute;
 
     return {
         oldSeverity: determineAttributeSeverityOrder(self, oldAttribute),


### PR DESCRIPTION
Modified the behavior when applying CVSS vector metrics conditionally based on their severity (using `applyVectorPartsIfMetricsLower` or `applyVectorPartsIfMetricsHigher`).

1. The logic used to determine if a modified attribute was set was inverted. It returned true if the attribute was not defined, meaning explicitly set modified metrics were ignored while unset metrics were treated as set.
2. Applying a new base metric incorrectly attempted to compare its severity against it's modified metric counterpart, instead of comparing only the base metric value.

An example:
If a vector was initialized as `CVSS:4.0/AV:N/MAV:L`, calling `applyVectorPartsIfMetricsLower` with `MAV:A` would incorrectly evaluate the severity against the base metric `AV:N` instead of the current effective severity `MAV:L`. Because `MAV:A` is less severe than `AV:N`, it incorrectly overwrote `MAV:L` to become `MAV:A`.